### PR TITLE
Fix build error on ARM

### DIFF
--- a/src/rtcp.rs
+++ b/src/rtcp.rs
@@ -6,19 +6,20 @@
 /// <https://tools.ietf.org/html/draft-alvestrand-rmcat-remb-03> (definition of REMB)
 
 use janus_plugin_sys as ffi;
+use std::os::raw::c_char;
 
 /// Returns whether this RTCP packet is a FIR packet.
-pub fn has_fir(packet: &[i8]) -> bool {
+pub fn has_fir(packet: &[c_char]) -> bool {
     unsafe { ffi::rtcp::janus_rtcp_has_fir(packet.as_ptr() as *mut _, packet.len() as i32) == 1 }
 }
 
 /// Returns whether this RTCP packet is a PLI packet.
-pub fn has_pli(packet: &[i8]) -> bool {
+pub fn has_pli(packet: &[c_char]) -> bool {
     unsafe { ffi::rtcp::janus_rtcp_has_pli(packet.as_ptr() as *mut _, packet.len() as i32) == 1 }
 }
 
 /// If this RTCP packet is an REMB packet, returns the bitrate it contains; else None.
-pub fn get_remb(packet: &[i8]) -> Option<u32> {
+pub fn get_remb(packet: &[c_char]) -> Option<u32> {
     unsafe {
         match ffi::rtcp::janus_rtcp_get_remb(packet.as_ptr() as *mut _, packet.len() as i32) {
             0 => None,
@@ -28,7 +29,7 @@ pub fn get_remb(packet: &[i8]) -> Option<u32> {
 }
 
 /// Allocates and writes a new FIR packet with the given sequence number. The given sequence number needs to be incremented before calling the function.
-pub fn gen_fir(seq: &mut i32) -> Vec<i8> {
+pub fn gen_fir(seq: &mut i32) -> Vec<c_char> {
     let mut packet = Vec::with_capacity(20);
     let result = unsafe { ffi::rtcp::janus_rtcp_fir(packet.as_mut_ptr(), 20, seq) };
     match result {
@@ -42,7 +43,7 @@ pub fn gen_fir(seq: &mut i32) -> Vec<i8> {
 }
 
 /// Allocates and writes a new PLI packet.
-pub fn gen_pli() -> Vec<i8> {
+pub fn gen_pli() -> Vec<c_char> {
     let mut packet = Vec::with_capacity(12);
     let result = unsafe { ffi::rtcp::janus_rtcp_pli(packet.as_mut_ptr(), 12) };
     match result {
@@ -56,7 +57,7 @@ pub fn gen_pli() -> Vec<i8> {
 }
 
 /// Allocates and writes a new REMB packet with the given bitrate.
-pub fn gen_remb(bitrate: u32) -> Vec<i8> {
+pub fn gen_remb(bitrate: u32) -> Vec<c_char> {
     let mut packet = Vec::with_capacity(24);
     let result = unsafe { ffi::rtcp::janus_rtcp_remb(packet.as_mut_ptr(), 24, bitrate) };
     match result {


### PR DESCRIPTION
I got the following error when building it on Raspberry Pi 2B:

```
error[E0308]: mismatched types
  --> /root/.cargo/git/checkouts/janus-plugin-rs-0e53092005fe3a9c/b059851/src/rtcp.rs:39:13
   |
31 | pub fn gen_fir(seq: &mut i32) -> Vec<i8> {
   |                                  ------- expected `Vec<i8>` because of return type
...
39 |             packet
   |             ^^^^^^ expected `i8`, found `u8`
   |
   = note: expected struct `Vec<i8>`
              found struct `Vec<u8>`
```

On some ARM platforms, the libc char type is "unsigned char" (u8) and not signed char (i8), the error is because we mix `std::os::raw::c_char` and `i8`.
On intel, `c_char` is an alias to `i8`, but on ARM it's an alias to `u8`, so I actually just needed to fix the type, so replacing all `i8` by `std::os::raw::c_char` (or `libc::c_char` see https://stackoverflow.com/questions/44436515/should-i-use-libcc-char-or-stdosrawc-char but `std::os::raw::c_char` was already used in the code so I used that) in `src/rtcp.rs`