### PR TITLE
Add api version 17 compatibility, require janus 0.12.0 minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ janus-plugin = "0.13.0"
 
 ## Compatibility
 
-Currently compatible with Janus versions >= 0.11.6; Janus makes breaking changes relatively frequently to
+Currently compatible with Janus versions >= 0.12.0; Janus makes breaking changes relatively frequently to
 the plugin API, so expect this library to require updating and recompilation for plugins to continue to work with new
 Janus versions.
 
@@ -69,7 +69,7 @@ const PLUGIN: Plugin = build_plugin!(
     LibraryMetadata {
         // The Janus plugin API version. The version compiled into the plugin
         // must be identical to the version in the Janus which loads the plugin.
-        api_version: 16,
+        api_version: 17,
         // Incrementing plugin version number for your own use.
         version: 1,
         // Human-readable metadata which Janus can query.

--- a/janus-plugin-sys/src/plugin.rs
+++ b/janus-plugin-sys/src/plugin.rs
@@ -1,5 +1,5 @@
 use jansson_sys::json_t;
-use std::os::raw::{c_char, c_int, c_void, c_short};
+use std::os::raw::{c_char, c_uchar, c_int, c_uint, c_void, c_short};
 use glib_sys::gboolean;
 
 #[repr(C)]
@@ -16,10 +16,10 @@ pub struct janus_callbacks {
     pub relay_rtcp: extern "C" fn(handle: *mut janus_plugin_session, packet: *mut janus_plugin_rtcp),
     pub relay_data: extern "C" fn(handle: *mut janus_plugin_session, packet: *mut janus_plugin_data),
     pub send_pli: extern "C" fn(handle: *mut janus_plugin_session),
-    pub send_remb: extern "C" fn(handle: *mut janus_plugin_session, bitrate: c_int),
+    pub send_remb: extern "C" fn(handle: *mut janus_plugin_session, bitrate: c_uint),
     pub close_pc: extern "C" fn(handle: *mut janus_plugin_session),
     pub end_session: extern "C" fn(handle: *mut janus_plugin_session),
-    pub events_is_enabled: extern "C" fn() -> c_int,
+    pub events_is_enabled: extern "C" fn() -> gboolean,
     pub notify_event: extern "C" fn(plugin: *mut janus_plugin, handle: *mut janus_plugin_session, event: *mut json_t),
     pub auth_is_signed: extern "C" fn() -> gboolean,
     pub auth_is_signature_valid: extern "C" fn(plugin: *mut janus_plugin, token: *const c_char) -> gboolean,
@@ -55,10 +55,14 @@ pub struct janus_plugin_result {
 #[derive(Debug)]
 pub struct janus_plugin_rtp_extensions {
     pub audio_level : c_char,
-    pub audio_level_vad : c_char,
+    pub audio_level_vad : gboolean,
     pub video_rotation : c_short,
-    pub video_back_camera : c_char,
-    pub video_flipped : c_char,
+    pub video_back_camera : gboolean,
+    pub video_flipped : gboolean,
+    pub min_delay : c_short,
+    pub max_delay : c_short,
+    pub dd_len : c_uchar,
+    pub dd_content : [c_uchar; 256],
 }
 
 #[repr(C)]

--- a/janus-plugin-sys/src/plugin.rs
+++ b/janus-plugin-sys/src/plugin.rs
@@ -1,5 +1,5 @@
 use jansson_sys::json_t;
-use std::os::raw::{c_char, c_uchar, c_int, c_uint, c_void, c_short};
+use std::os::raw::{c_char, c_uchar, c_int, c_uint, c_void, c_short, c_ushort};
 use glib_sys::gboolean;
 
 #[repr(C)]
@@ -68,18 +68,18 @@ pub struct janus_plugin_rtp_extensions {
 #[repr(C)]
 #[derive(Debug)]
 pub struct janus_plugin_rtp {
-    pub video :  c_char,
+    pub video :  gboolean,
     pub buffer : *mut c_char,
-    pub length : c_short,
+    pub length : c_ushort,
     pub extensions : janus_plugin_rtp_extensions,
 }
 
 #[repr(C)]
 #[derive(Debug)]
 pub struct janus_plugin_rtcp {
-    pub video : c_char,
+    pub video : gboolean,
     pub buffer : *mut c_char,
-    pub length : c_short,
+    pub length : c_ushort,
 }
 
 #[repr(C)]
@@ -89,7 +89,7 @@ pub struct janus_plugin_data {
     pub protocol : *mut c_char,
     pub binary : c_char,
     pub buffer : *mut c_char,
-    pub length : c_short,
+    pub length : c_ushort,
 }
 
 #[repr(C)]


### PR DESCRIPTION
To be compared with https://github.com/meetecho/janus-gateway/blob/7b6bcdcdbe02dd05932d778592f4c03604a83684/plugins/plugin.h in 0.x branch (commit from v0.13.0)